### PR TITLE
Fix typo in Github auth component

### DIFF
--- a/src/modules/CompleteAuthentication.tsx
+++ b/src/modules/CompleteAuthentication.tsx
@@ -18,7 +18,7 @@ import { GITHUB_REDIRECT_URI, GITHUB_CLIENT_ID } from '../constants';
 import { GithubHandler } from '../handlers';
 import { Footer } from './Footer';
 
-const AuthorizeWithGtihub = ({ nextStep }: { nextStep: Function }) => {
+const AuthorizeWithGithub = ({ nextStep }: { nextStep: Function }) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
 
   const handleClicked = () => {
@@ -218,4 +218,4 @@ const StartOnboarding = ({ nextStep }: { nextStep: Function }) => {
   );
 };
 
-export { StartOnboarding, AuthorizeWithGtihub, AuthorizeWithLeetCode, SelectRepositoryStep };
+export { StartOnboarding, AuthorizeWithGithub, AuthorizeWithLeetCode, SelectRepositoryStep };

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -1,7 +1,7 @@
 import { CircularProgress, Container, Heading, VStack } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
 import {
-  AuthorizeWithGtihub,
+  AuthorizeWithGithub,
   AuthorizeWithLeetCode,
   SelectRepositoryStep,
   StartOnboarding,
@@ -44,7 +44,7 @@ const getUserData = async (): Promise<Partial<UserGlobalData>> => {
 
 const STEPS_TO_COMPONENT = {
   0: StartOnboarding,
-  1: AuthorizeWithGtihub,
+  1: AuthorizeWithGithub,
   2: AuthorizeWithLeetCode,
   3: SelectRepositoryStep,
 };
@@ -69,7 +69,7 @@ const PopupPage: React.FC<PopupProps> = () => {
       return <StartOnboarding nextStep={nextStep} />;
     }
     if (step === 1) {
-      return <AuthorizeWithGtihub nextStep={nextStep} />;
+      return <AuthorizeWithGithub nextStep={nextStep} />;
     }
     if (step === 2) {
       return <AuthorizeWithLeetCode nextStep={nextStep} />;


### PR DESCRIPTION
## Summary
- rename `AuthorizeWithGtihub` to `AuthorizeWithGithub`
- update popup page to use the new name

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684330e5c524832f845daf68afa3891e