### PR TITLE
Update instructions for syncing repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To configure LeetSync, follow these steps:
 1. Click on the extension icon in your Chrome toolbar.
 2. In the popup window, Give Access via Github.
 3. Login Via LeetCode (Optional and might be automatically skipped if already logged in)
-4. Select the repository you want to sync your submissions to.
-5. Start solving some problems
+4. Select the repository you want to sync your submissions to. Make sure that the link is of the form `https://github.com/my-username/my-repository-name`. **No `.git` after repository name.**
+6. Start solving some problems
 
 ## Usage
 


### PR DESCRIPTION
**Clarified repository link format for syncing submissions.**

Reason For adding clarification:
- In Step 3 using link like `https://github.com/my-username/my-repository-name.git`, code resolves repository name as `my-rpository-name.git`
- And since, upload uses GitHub API path `.../repos/{user}/{repo}/contents/...`, it expects repository name as `my-repository-name` not `my-repository-name.git`
- So using link `https://github.com/my-username/my-repository-name.git` causes GitHub requests to fail silently.