### PR TITLE
fix: resolve incorrect question folder prefixes and add Pandas support

### DIFF
--- a/src/handlers/GithubHandler.ts
+++ b/src/handlers/GithubHandler.ts
@@ -319,7 +319,7 @@ export default class GithubHandler {
       return false;
     }
     //create a path for the files to be uploaded
-    let basePath = `${question.questionFrontendId ?? question.questionId ?? 'unknown'}-${question.titleSlug}`;
+    let basePath = `${question.frontendQuestionId ?? question.questionFrontendId ?? question.questionId ?? 'unknown'}-${question.titleSlug}`;
 
     if (this.github_leetsync_subdirectory) {
       basePath = `${this.github_leetsync_subdirectory}/${basePath}`;

--- a/src/handlers/GithubHandler.ts
+++ b/src/handlers/GithubHandler.ts
@@ -10,6 +10,8 @@ type DistributionType = {
 const languagesToExtensions: Record<string, string> = {
   Python: '.py',
   Python3: '.py',
+  Pandas: '.py',
+  pythondata: '.py',
   'C++': '.cpp',
   C: '.c',
   Java: '.java',

--- a/src/modules/Dashboard.tsx
+++ b/src/modules/Dashboard.tsx
@@ -90,7 +90,7 @@ const Dashboard: React.FC<DashboardProps> = ({}) => {
         setGithubRepo(github_leetsync_repo);
         if (!problemsSolved) return;
         let [easy, medium, hard] = [0, 0, 0];
-        const problemSolvedValues = Object.values(problemsSolved);
+        const problemSolvedValues = Object.values(problemsSolved) as any[];
         problemSolvedValues.forEach((problem: any) => {
           if (problem.question.difficulty === 'Easy') {
             easy++;

--- a/src/types/Question.d.ts
+++ b/src/types/Question.d.ts
@@ -13,6 +13,7 @@ export class QuestionListFilterInput {
 export class Question {
   questionId: string;
   questionFrontendId?: string;
+  frontendQuestionId?: string;
   title: string;
   titleSlug: string;
   difficulty: QuestionDifficulty;


### PR DESCRIPTION
This PR fixes a bug where LeetSync prefixes synced folders with incorrect sequence numbers (falling back to LeetCode's internal database `questionId` instead of using the user-visible question sequence number).

### Summary of Changes
* **Update `GithubHandler.ts`**: Checks `frontendQuestionId` before falling back to `questionFrontendId` or `questionId` when building folder names.
* **Add `frontendQuestionId` type declaration**: Added `frontendQuestionId?: string;` property to the `Question` class in `Question.d.ts`.
* **Fix TypeScript compilation error**: Added a quick type cast `as any[]` in `Dashboard.tsx` to prevent build issues during packaging.

---

## Code Changes

### `src/handlers/GithubHandler.ts`
```typescript
<<<<
    //create a path for the files to be uploaded
    let basePath = `${question.questionFrontendId ?? question.questionId ?? 'unknown'}-${question.titleSlug}`;
====
    //create a path for the files to be uploaded
    let basePath = `${question.frontendQuestionId ?? question.questionFrontendId ?? question.questionId ?? 'unknown'}-${question.titleSlug}`;
>>>>
```

### `src/types/Question.d.ts`
```typescript
<<<<
export class Question {
  questionId: string;
  questionFrontendId?: string;
  title: string;
====
export class Question {
  questionId: string;
  questionFrontendId?: string;
  frontendQuestionId?: string;
  title: string;
>>>>
```

### `src/modules/Dashboard.tsx`
```typescript
<<<<
        const problemSolvedValues = Object.values(problemsSolved);
        problemSolvedValues.forEach((problem: any) => {
====
        const problemSolvedValues = Object.values(problemsSolved) as any[];
        problemSolvedValues.forEach((problem: any) => {
>>>>
```